### PR TITLE
wrong order causes executable to not work

### DIFF
--- a/sensu-plugins-influxdb.gemspec
+++ b/sensu-plugins-influxdb.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for influxDB'
   s.email                  = '<sensu-users@googlegroups.com>'
-  s.executables            = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.executables            = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-influxdb'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => '@mattyjones',


### PR DESCRIPTION
without this change, the rb files wont be on path for execution
